### PR TITLE
Adds collision export

### DIFF
--- a/Send to Unreal/addon/functions/export.py
+++ b/Send to Unreal/addon/functions/export.py
@@ -284,6 +284,17 @@ def export_fbx_files(file_paths, properties):
     set_object_positions(original_positions)
 
 
+def is_collision_of(asset_name, mesh_object_name):
+    return bool(re.fullmatch(r"U(BX|CP|SP|CX)_" + asset_name + r"(_\d+)?", mesh_object_name))
+
+
+def select_asset_collisions(asset_name, properties):
+    collision_objects = get_from_collection(properties.collision_collection_name, 'MESH')
+    for mesh_object in collision_objects:
+        if is_collision_of(asset_name, mesh_object.name):
+            mesh_object.select_set(True)
+
+
 def export_mesh_lods(asset_name, properties):
     """
     This function exports a set of lod meshes to an fbx file.
@@ -322,6 +333,9 @@ def export_mesh_lods(asset_name, properties):
 
                 # select the lod mesh
                 mesh_object.select_set(True)
+        
+        # select collsion meshes
+        select_asset_collisions(asset_name, properties)
 
         # export the selected lod meshes and empty
         fbx_file_paths = get_fbx_paths(asset_name, 'MESH')
@@ -357,6 +371,9 @@ def export_mesh(mesh_object, properties):
 
     # select any rigs this object is parented too
     set_parent_rig_selection(mesh_object, properties)
+
+    # select collision meshes
+    select_asset_collisions(mesh_object.name, properties)
 
     # export selection to an fbx file
     export_fbx_files(fbx_file_paths, properties)

--- a/Send to Unreal/addon/properties.py
+++ b/Send to Unreal/addon/properties.py
@@ -9,9 +9,10 @@ class Send2UeProperties:
     """
     # read only properties
     module_name = __package__
-    collection_names = ['Mesh', 'Rig', 'Extras']
+    collection_names = ['Mesh', 'Rig', 'Collision', 'Extras']
     mesh_collection_name = 'Mesh'
     rig_collection_name = 'Rig'
+    collision_collection_name = 'Collision'
 
     # blender default project settings
     default_unit_scale = 1


### PR DESCRIPTION
Adds a basic support for collision export (fixes #22)

* Creates a 'Collision' collection
* Matches the mesh name using the `UBX_`, `UCP_`, `USP_` and `UCX_` prefixes (as defined in [docs](https://docs.unrealengine.com/en-US/Engine/Content/Importing/FBX/StaticMeshes/index.html))
* Allow to define numbered suffixes (`_01`, `_02`, ...) or no suffix at all