### PR TITLE
Allow empty node sockets

### DIFF
--- a/ue2rigify/addon/__init__.py
+++ b/ue2rigify/addon/__init__.py
@@ -14,7 +14,7 @@ bl_info = {
     "author": "Epic Games Inc.",
     "description": "Allows you to convert a given rig and its animations to a Rigify rig.",
     "blender": (2, 83, 0),
-    "version": (1, 3, 11),
+    "version": (1, 3, 12),
     "location": "3D View > Tools > UE to Rigify",
     "wiki_url": "https://github.com/EpicGames/BlenderTools/wiki/UE-to-Rigify-Home",
     "warning": "",

--- a/ue2rigify/addon/functions/scene.py
+++ b/ue2rigify/addon/functions/scene.py
@@ -52,13 +52,14 @@ def get_keyframes(fcurve, bone, data_path, keyed_values):
     :return list: A list of keyed values.
     """
     # only save the rotation key frames if they match the current rotation mode
-    if 'rotation_euler' == data_path:
-        if len(bone.rotation_mode) != 3:
-            return keyed_values
+    if bone:
+        if 'rotation_euler' == data_path:
+            if len(bone.rotation_mode) != 3:
+                return keyed_values
 
-    if 'rotation_quaternion' == data_path:
-        if bone.rotation_mode.lower() not in data_path:
-            return keyed_values
+        if 'rotation_quaternion' == data_path:
+            if bone.rotation_mode.lower() not in data_path:
+                return keyed_values
 
     for keyframe_point in fcurve.keyframe_points:
         # get the original key frame value


### PR DESCRIPTION
fixes bug when empty node sockets are in a template. Mentioned in #12  