### PR TITLE
Use SIGTERM instead of CTRL_C_EVENT to avoid KeyboardInterrupt exception

### DIFF
--- a/test/scripts/unreal_utilities.py
+++ b/test/scripts/unreal_utilities.py
@@ -201,7 +201,7 @@ def close_unreal(unreal_process):
         if unreal_response:
             if unreal_response['success']:
                 process_id = int(unreal_response['output'][0]['output'])
-                os.kill(process_id, signal.CTRL_C_EVENT)
+                os.kill(process_id, signal.SIGTERM)
 
     # TODO needs to be tested on macOS
     else:


### PR DESCRIPTION
Use SIGTERM instead of CTRL_C_EVENT so that run_unit_tests.py doesn't terminate early with KeyboardInterrupt.

Previously, I'd get a unit test log that ended like this:

```
----------------------------------------------------------------------
Ran 16 tests in 42.928s

OK

Traceback (most recent call last):
  File "run_unit_tests.py", line 28, in <module>
    logger.info(f'\n{read_log_file.read()}')
  File "C:\Users\doug\AppData\Local\Programs\Python\Python38\lib\logging\__init__.py", line 1434, in info
    self._log(INFO, msg, args, **kwargs)
  File "C:\Users\doug\AppData\Local\Programs\Python\Python38\lib\logging\__init__.py", line 1577, in _log
    self.handle(record)
  File "C:\Users\doug\AppData\Local\Programs\Python\Python38\lib\logging\__init__.py", line 1587, in handle
    self.callHandlers(record)
  File "C:\Users\doug\AppData\Local\Programs\Python\Python38\lib\logging\__init__.py", line 1646, in callHandlers
    for hdlr in c.handlers:
KeyboardInterrupt
```

Now the log ends like this:

```
----------------------------------------------------------------------
Ran 16 tests in 42.815s

OK
```

After my change, I made sure UE4Editor-Cmd was shutdown after the unit tests completed.