### PR TITLE
Fix False Error Detection When Name As Root Option is False

### DIFF
--- a/send2ue/addon/functions/unreal.py
+++ b/send2ue/addon/functions/unreal.py
@@ -52,8 +52,6 @@ def import_asset(asset_data, properties):
     """
     # Get the expected unreal asset name so we can check if the file was properly created after import.
     short_name = os.path.splitext(os.path.basename(asset_data.get("fbx_file_path")))[0]
-    print(short_name)
-    print(asset_data.get("game_path"))
     game_file = (asset_data.get("game_path") + '/' + short_name).replace('//', '/')
 
     # start a connection to the engine that lets you send python strings


### PR DESCRIPTION
Error was being detected by trying to load the import asset in Unreal, but the path being used load the asset was its parent folder, not the asset's path.