### PR TITLE
Fix editor asset library error

### DIFF
--- a/test/unreal_projects/test_project_01/test_project_01.uproject
+++ b/test/unreal_projects/test_project_01/test_project_01.uproject
@@ -7,6 +7,10 @@
 		{
 			"Name": "PythonScriptPlugin",
 			"Enabled": true
+		},
+		{
+			"Name": "EditorScriptingUtilities",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
There are several errors like this in test_project_01.log when the unit tests are run:

```
[2020.12.13-20.53.43:790][117]LogPython: Error: Traceback (most recent call last):
[2020.12.13-20.53.43:790][117]LogPython: Error:   File "<string>", line 1, in <module>
[2020.12.13-20.53.43:790][117]LogPython: Error: AttributeError: module 'unreal' has no attribute 'EditorAssetLibrary'
```

The test project was not including the EditorScriptingUtilities plugin, which implements the unreal.EditorAssetLibrary module.

Ran unit tests, and the error no longer appears in test_project_01.log.