### PR TITLE
python 3.9 fix

### DIFF
--- a/send2ue/addon/dependencies/remote_execution.py
+++ b/send2ue/addon/dependencies/remote_execution.py
@@ -585,7 +585,7 @@ class _RemoteExecutionMessage(object):
             bool: True if this message could be parsed, False otherwise.
         '''
         try:
-            json_obj = _json.loads(json_str, encoding='utf-8')
+            json_obj = _json.loads(json_str)
             # Read and validate required protocol version information
             if json_obj['version'] != _PROTOCOL_VERSION:
                 raise ValueError(


### PR DESCRIPTION
removed encoding parameter from json.loads() so unittests are compatible with python 3.9
#179