### PR TITLE
Fix use Object Origin on Export

### DIFF
--- a/send2ue/addon/functions/utilities.py
+++ b/send2ue/addon/functions/utilities.py
@@ -528,11 +528,10 @@ def combine_child_meshes(properties):
 
     :param object properties: The property group that contains variables that maintain the addon's correct state.
     """
-    selected_object_names = []
+    selected_object_names = [selected_object.name for selected_object in bpy.context.selected_objects]
     duplicate_object_names = []
 
     if properties.combine_child_meshes:
-        selected_object_names = [selected_object.name for selected_object in bpy.context.selected_objects]
         selected_objects = bpy.context.selected_objects.copy()
 
         if bpy.context.mode != 'OBJECT':


### PR DESCRIPTION
Fixes the use object origin on export, even if "combine child meshes" is disabled.

Return the "**selected_object_names** " with the correct value by setting it sooner rather than later, as it was not being taken into account whether "combine child meshes" was enabled or not.