### PR TITLE
Send to Unreal 1.8.0

### DIFF
--- a/docs/send2ue/preferences/validations.md
+++ b/docs/send2ue/preferences/validations.md
@@ -7,9 +7,13 @@ folder: ""
 
 <iframe src="https://www.youtube.com/embed/1MrE2PMDkqg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+### Check scene units:
+
+This checks the scene units and ensures they are set to metric, and the scene scale is 1.
+
 ### Check armatures for un-applied transforms:
 
-If an armature object has un-applied transforms a message is thrown to the user
+If an armature object has un-applied transforms a message is thrown to the user.
 
 ### Check if asset has unused materials:
 

--- a/send2ue/addon/__init__.py
+++ b/send2ue/addon/__init__.py
@@ -15,7 +15,7 @@ from .functions import export, unreal, validations, utilities
 bl_info = {
     "name": "Send to Unreal",
     "author": "Epic Games Inc.",
-    "version": (1, 7, 2),   # addon plugin version
+    "version": (1, 8, 0),   # addon plugin version
     "blender": (2, 83, 0),  # minimum blender version
     "location": "Header > Pipeline > Export > Send to Unreal",
     "description": "Sends an asset to the first open Unreal Editor instance on your machine.",

--- a/send2ue/addon/functions/export.py
+++ b/send2ue/addon/functions/export.py
@@ -755,50 +755,50 @@ def create_mesh_data(mesh_objects, rig_objects, properties):
     :return list: A list of dictionaries containing the mesh import data.
     """
     mesh_data = []
-    # don't import meshes if importing onto an existing skeleton
-    if not properties.unreal_skeleton_asset_path:
-        # if importing lods
-        if properties.import_lods:
-            exported_asset_names = []
+    # if importing lods
+    if properties.import_lods:
+        exported_asset_names = []
 
-            # recreate the lod meshes to ensure the correct order
-            mesh_objects = utilities.recreate_lod_meshes(mesh_objects)
+        # recreate the lod meshes to ensure the correct order
+        mesh_objects = utilities.recreate_lod_meshes(mesh_objects)
 
-            for mesh_object in mesh_objects:
-                # get the name of the asset without the lod postfix
-                asset_name = utilities.get_unreal_asset_name(mesh_object.name, properties)
+        for mesh_object in mesh_objects:
+            # get the name of the asset without the lod postfix
+            asset_name = utilities.get_unreal_asset_name(mesh_object.name, properties)
 
-                # if this asset name is not in the list of exported assets names
-                if asset_name not in exported_asset_names:
-                    # export the asset's lod meshes
-                    fbx_file_paths = export_mesh_lods(asset_name, properties)
-
-                    # save the asset data
-                    mesh_data.append({
-                        'fbx_file_path': fbx_file_paths.get('unreal'),
-                        'game_path': utilities.get_full_import_path(mesh_object, properties),
-                        'skeletal_mesh': bool(rig_objects),
-                        'import_mesh': True,
-                        'lods': True
-                    })
-
-                    # add this asset to the list of exported assets
-                    exported_asset_names.append(asset_name)
-
-        # otherwise if not importing lods
-        else:
-            # get the asset data for the scene objects
-            for mesh_object in mesh_objects:
-                # export the object
-                fbx_file_paths = export_mesh(mesh_object, properties)
+            # if this asset name is not in the list of exported assets names
+            if asset_name not in exported_asset_names:
+                # export the asset's lod meshes
+                fbx_file_paths = export_mesh_lods(asset_name, properties)
 
                 # save the asset data
                 mesh_data.append({
                     'fbx_file_path': fbx_file_paths.get('unreal'),
                     'game_path': utilities.get_full_import_path(mesh_object, properties),
                     'skeletal_mesh': bool(rig_objects),
-                    'import_mesh': True
+                    'skeleton_game_path': properties.unreal_skeleton_asset_path,
+                    'import_mesh': True,
+                    'lods': True
                 })
+
+                # add this asset to the list of exported assets
+                exported_asset_names.append(asset_name)
+
+    # otherwise if not importing lods
+    else:
+        # get the asset data for the scene objects
+        for mesh_object in mesh_objects:
+            # export the object
+            fbx_file_paths = export_mesh(mesh_object, properties)
+
+            # save the asset data
+            mesh_data.append({
+                'fbx_file_path': fbx_file_paths.get('unreal'),
+                'game_path': utilities.get_full_import_path(mesh_object, properties),
+                'skeletal_mesh': bool(rig_objects),
+                'skeleton_game_path': properties.unreal_skeleton_asset_path,
+                'import_mesh': True
+            })
 
     return mesh_data
 
@@ -849,6 +849,12 @@ def validate(properties):
     if not validations.validate_collections_exist(properties):
         return False
 
+    if not validations.validate_object_names(mesh_objects, rig_objects):
+        return False
+
+    if not validations.validate_scene_units(properties):
+        return False
+
     if not validations.validate_geometry_exists(mesh_objects):
         return False
 
@@ -856,9 +862,6 @@ def validate(properties):
         return False
 
     if not validations.validate_unreal_paths(properties):
-        return False
-
-    if not validations.validate_unreal_skeleton_path(unreal, properties):
         return False
 
     if properties.validate_materials:

--- a/send2ue/addon/functions/unreal.py
+++ b/send2ue/addon/functions/unreal.py
@@ -83,18 +83,16 @@ def import_asset(asset_data, properties):
             f'\toptions.mesh_type_to_import = unreal.FBXImportType.FBXIT_STATIC_MESH',
             f'\toptions.static_mesh_import_data.import_mesh_lo_ds = {bool(asset_data.get("lods"))}',
 
+            # try to load the provided skeleton
+            f'skeleton_asset = unreal.load_asset(r"{asset_data.get("skeleton_game_path")}")',
+            f'if skeleton_asset:',
+            f'\toptions.set_editor_property("skeleton", skeleton_asset)',
+
             # if this is an animation import
             f'if {bool(asset_data.get("animation"))}:',
-            f'\tskeleton_asset = unreal.load_asset(r"{asset_data.get("skeleton_game_path")}")',
-
-            # if a skeleton can be loaded from the provided path
-            f'\tif skeleton_asset:',
-            f'\t\toptions.set_editor_property("skeleton", skeleton_asset)',
-            f'\t\toptions.set_editor_property("original_import_type", unreal.FBXImportType.FBXIT_ANIMATION)',
-            f'\t\toptions.set_editor_property("mesh_type_to_import", unreal.FBXImportType.FBXIT_ANIMATION)',
-            f'\t\toptions.anim_sequence_import_data.set_editor_property("preserve_local_transform", True)',
-            f'\telse:',
-            f'\t\traise RuntimeError("Unreal could not find a skeleton here: {asset_data.get("skeleton_game_path")}")',
+            f'\toptions.set_editor_property("original_import_type", unreal.FBXImportType.FBXIT_ANIMATION)',
+            f'\toptions.set_editor_property("mesh_type_to_import", unreal.FBXImportType.FBXIT_ANIMATION)',
+            f'\toptions.anim_sequence_import_data.set_editor_property("preserve_local_transform", True)',
 
             # assign the options object to the import task and import the asset
             f'import_task.options = options',

--- a/send2ue/addon/functions/utilities.py
+++ b/send2ue/addon/functions/utilities.py
@@ -7,6 +7,7 @@ import math
 import shutil
 import tempfile
 from mathutils import Vector, Quaternion
+from . import unreal
 
 
 def get_action_name(action_name, properties):
@@ -986,7 +987,7 @@ def auto_format_unreal_skeleton_asset_path(self, value):
     # Make sure the skeleton path to unreal is correct as the engine will
     # hard crash if passed an incorrect path
     self.incorrect_unreal_skeleton_path = False
-    if self.unreal_skeleton_asset_path and not self.unreal_skeleton_asset_path.lower().startswith("/game"):
+    if self.unreal_skeleton_asset_path and not unreal.asset_exists(self.unreal_skeleton_asset_path):
         self.incorrect_unreal_skeleton_path = True
 
 

--- a/send2ue/addon/functions/validations.py
+++ b/send2ue/addon/functions/validations.py
@@ -27,6 +27,49 @@ def validate_collections_exist(properties):
     return True
 
 
+def validate_object_names(mesh_objects, rig_objects):
+    """
+    This function checks each object to see if the name of the object matches the supplied regex expression.
+
+    :param list mesh_objects: The list of mesh objects to be validated.
+    :param list rig_objects: The list of armature objects to be validated.
+    :return bool: True if the objects passed the validation.
+    """
+    for scene_object in mesh_objects + rig_objects:
+        # check if the object name is none
+        if scene_object.name.lower() in ['none']:
+            utilities.report_error(
+                f'Object "{scene_object.name}" has an invalid name. Please rename it.'
+            )
+            return False
+    return True
+
+
+def validate_scene_units(properties):
+    """
+    This function checks each object to see if the name of the object matches the supplied regex expression.
+
+    :param object properties: The property group that contains variables that maintain the addon's correct state.
+    :return bool: True if the objects passed the validation.
+    """
+    if properties.validate_unit_settings:
+        unit_settings = bpy.context.scene.unit_settings
+        if unit_settings.system != 'METRIC':
+            utilities.report_error(
+                f'"{unit_settings.system}" unit system is not recommended. Please change to "METRIC", or disable '
+                f'this validation.'
+            )
+            return False
+
+        if round(unit_settings.scale_length, 2) != 1.00:
+            utilities.report_error(
+                f'Unit scale {round(unit_settings.scale_length, 2)} is not recommended. Please change to 1.0, '
+                f'or disable this validation.'
+            )
+            return False
+    return True
+
+
 def validate_geometry_exists(mesh_objects):
     """
     This function checks the geometry of each object to see if it has vertices.
@@ -212,31 +255,14 @@ def validate_unreal_path_by_property(properties, property_name, detailed_message
 
         if property_name == "incorrect_unreal_skeleton_path":
             if getattr(properties, property_name):
-                message = f'The skeleton asset name "{properties.unreal_skeleton_asset_path}" needs to start with "/Game`". '
+                message = f'The skeleton asset "{properties.unreal_skeleton_asset_path}" does not exist in unreal.'
 
                 if detailed_message:
-                    message += f'Please make sure that the path under "Skeleton Asset (Unreal)" was entered correctly.'
+                    message += f' Please make sure that the path under "Skeleton Asset (Unreal)" was entered correctly.'
 
             return message
 
     return message
-
-
-def validate_unreal_skeleton_path(unreal, properties):
-    """
-    This function checks to make sure this skeleton exists in unreal.
-
-    :param object unreal: The unreal utilities module.
-    :param object properties: The property group that contains variables that maintain the addon's correct state.
-    :return bool: True if the objects passed the validation.
-    """
-    if properties.unreal_skeleton_asset_path:
-        if not unreal.asset_exists(properties.unreal_skeleton_asset_path):
-            utilities.report_error(
-                f'There is no skeleton in your unreal project at: "{properties.unreal_skeleton_asset_path}".'
-            )
-            return False
-    return True
 
 
 def validate_geometry_materials(mesh_objects):

--- a/send2ue/addon/properties.py
+++ b/send2ue/addon/properties.py
@@ -49,7 +49,7 @@ class Send2UeUIProperties:
         ],
         default="paths",
         description="Select which preferences you want to edit"
-    )    
+    )
     automatically_create_collections: bpy.props.BoolProperty(
         name="Automatically create pre-defined addon collections",
         default=True,
@@ -212,6 +212,20 @@ class Send2UeUIProperties:
         default=False,
         description="When enabled this option launches the FBX import UI in Unreal"
     )
+    validate_unit_settings: bpy.props.BoolProperty(
+        name="Check scene units",
+        default=True,
+        description=(
+            "This checks the scene units and ensures they are set to metric, and the scene scale is 1"
+        )
+    )
+    validate_armature_transforms: bpy.props.BoolProperty(
+        name="Check armatures for un-applied transforms",
+        default=True,
+        description=(
+            "If an armature object has un-applied transforms a message is thrown to the user"
+        )
+    )
     validate_materials: bpy.props.BoolProperty(
         name="Check if asset has unused materials",
         default=False,
@@ -227,13 +241,6 @@ class Send2UeUIProperties:
         description=(
             "If a texture referenced in an object’s material can not be found in the blend file data than a error "
             "message is thrown to the user"
-        )
-    )
-    validate_armature_transforms: bpy.props.BoolProperty(
-        name="Check armatures for un-applied transforms",
-        default=True,
-        description=(
-            "If an armature object has un-applied transforms a message is thrown to the user"
         )
     )
 

--- a/send2ue/addon/ui/addon_preferences.py
+++ b/send2ue/addon/ui/addon_preferences.py
@@ -25,7 +25,7 @@ class SendToUnrealPreferences(Send2UeProperties, Send2UeUIProperties, bpy.types.
         row = layout.row()
         row.prop(properties, 'options_type', expand=True)
 
-        if properties.options_type == 'general':            
+        if properties.options_type == 'general':
             row = layout.row()
             row.prop(properties, 'automatically_create_collections')
 
@@ -45,7 +45,6 @@ class SendToUnrealPreferences(Send2UeProperties, Send2UeUIProperties, bpy.types.
 
                 # disable the mesh folder path input if a skeleton path is provided
                 row = layout.row()
-                row.enabled = not bool(properties.unreal_skeleton_asset_path)
                 row.alert = properties.incorrect_unreal_mesh_folder_path
                 row.prop(properties, 'unreal_mesh_folder_path', text='')
                 utilities.report_path_error_message(
@@ -227,6 +226,8 @@ class SendToUnrealPreferences(Send2UeProperties, Send2UeUIProperties, bpy.types.
                 row.prop(properties, 'use_metadata')
 
         if properties.options_type == 'validations':
+            row = layout.row()
+            row.prop(properties, 'validate_unit_settings')
             row = layout.row()
             row.prop(properties, 'validate_armature_transforms')
             row = layout.row()

--- a/test/scripts/unreal_utilities.py
+++ b/test/scripts/unreal_utilities.py
@@ -185,6 +185,27 @@ def delete_directory(directory_path):
         raise RuntimeError(f"delete_directory failed to delete {directory_path}")
 
 
+def delete_asset(asset_path):
+    """
+    This function deletes an unreal asset from the project.
+
+    :param str asset_path: The game path to the unreal project folder.
+    """
+    # start a connection to the engine that lets you send python strings
+    remote_exec = RemoteExecution()
+    remote_exec.start()
+
+    # send over the python code as a string
+    run_unreal_python_commands(
+        remote_exec,
+        '\n'.join([
+            f'unreal.EditorAssetLibrary.delete_asset(r"{asset_path}")',
+        ]))
+
+    if unreal_response is None or not unreal_response['success']:
+        raise RuntimeError(f"delete_asset failed to delete {asset_path}")
+
+
 def is_unreal_running(attempts, ping):
     """
     This function suspends the program execution until unreal remote execution socket responds.

--- a/test/unit_tests/send2ue_collections.py
+++ b/test/unit_tests/send2ue_collections.py
@@ -1,0 +1,76 @@
+# Copyright Epic Games, Inc. All Rights Reserved.
+import os
+import bpy
+import unittest
+import unreal_utilities
+
+
+class Send2UeCollections(unittest.TestCase):
+    """
+    related issue:
+    https://github.com/EpicGames/BlenderTools/issues/249
+    This feature allows swapping out meshes on existing skeletons.
+    """
+
+    def setUp(self):
+        # load in the file you will run tests on
+        bpy.ops.wm.open_mainfile(filepath=os.path.join(os.environ['BLENDS'], 'skeletal_meshes.blend'))
+
+        # enable the required addons
+        bpy.ops.preferences.addon_enable(module='send2ue')
+        bpy.ops.preferences.addon_enable(module='ue2rigify')
+        bpy.ops.preferences.addon_enable(module='rigify')
+
+    def tearDown(self):
+        # restore blend file to the default test file
+        bpy.ops.wm.open_mainfile(filepath=os.path.join(os.environ['BLENDS'], 'default_startup.blend'))
+
+    def test_import_on_existing_skeleton(self):
+        """
+        This method sends a skeletal mannequin mesh with animation to unreal.
+        """
+        properties = bpy.context.preferences.addons['send2ue'].preferences
+
+        mannequin = bpy.data.objects['SK_Mannequin']
+        mannequin_rig = bpy.data.objects['root']
+
+        # move the mannequin mesh to the mesh collection
+        bpy.data.collections['Mesh'].objects.link(mannequin)
+        bpy.context.scene.collection.objects.unlink(mannequin)
+
+        # move the mannequin rig to the rig collection
+        bpy.data.collections['Rig'].objects.link(mannequin_rig)
+        bpy.context.scene.collection.objects.unlink(mannequin_rig)
+
+        # run the send to unreal operation
+        bpy.ops.wm.send2ue()
+
+        # delete the skeletal mesh
+        unreal_utilities.delete_asset('/Game/untitled_category/untitled_asset/SK_Mannequin')
+
+        # delete the animation directory
+        unreal_utilities.delete_directory('/Game/untitled_category/untitled_asset/animations')
+
+        properties.unreal_mesh_folder_path = '/Game/test/'
+        properties.unreal_skeleton_asset_path = '/Game/untitled_category/untitled_asset/SK_Mannequin_Skeleton'
+
+        # run the send to unreal operation
+        bpy.ops.wm.send2ue()
+
+        # check if the mannequin skeletal mesh exists in the unreal project
+        self.assertTrue(unreal_utilities.asset_exists('/Game/test/SK_Mannequin'))
+
+        # check that the mannequin skeleton does not exist in the unreal project
+        self.assertFalse(unreal_utilities.asset_exists('/Game/test/SK_Mannequin_Skeleton'))
+
+        # check if the mannequin animation exists in the unreal project
+        self.assertTrue(unreal_utilities.asset_exists(
+            '/Game/untitled_category/untitled_asset/animations/third_person_run_01'
+        ))
+        self.assertTrue(unreal_utilities.asset_exists(
+            '/Game/untitled_category/untitled_asset/animations/third_person_walk_01'
+        ))
+
+        # delete all the assets created by the import
+        unreal_utilities.delete_directory('/Game/untitled_category/untitled_asset')
+        unreal_utilities.delete_directory('/Game/test')

--- a/test/unit_tests/send2ue_general.py
+++ b/test/unit_tests/send2ue_general.py
@@ -34,7 +34,6 @@ class Send2UeGeneralTestCases(unittest.TestCase):
         for coll in properties.collection_names:
             self.assertTrue(bpy.data.collections.get(coll))
 
-
     def test_predefined_collections_not_created(self):
         """
         Checks that the pre-defined collections haven't been automatically created by the addon.


### PR DESCRIPTION
Allow skeletal mesh imports directly onto a specified skeleton
![image](https://user-images.githubusercontent.com/67345633/113932593-6853d300-97b9-11eb-857b-e967188d90ea.png)
Mesh field is no longer grayed out when an existing skeleton is specified
#249

Added validation for unit system
#278

Added validation for objects named NONE
#275