### PR TITLE
Send to Unreal 1.8.4, UE to Rigify 1.5.8

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -92,6 +92,7 @@ OK
 `run_unit_tests.py` can be given several environment variables:
 * `TEST_CASES` can be used to specify which only which unitest you would like to run. `TEST_CASES=ue2rigify_baking.py,ue2rigify_modes.py,send2ue_collision_meshes.py`
 * `ONLY_BLENDER` can be used to specify whether to launch unreal or just run the tests in blender. `ONLY_BLENDER=True`
+* `UNREAL` can be used to specify which Unreal executable name to use. The default is `UE4Editor-Cmd` for Unreal Engine 4 versions. For Unreal 5 set the variable like so `UNREAL=UnrealEditor-Cmd`.
 
 ## Our Standards
 Our primary standard for code is [PEP 8](https://www.python.org/dev/peps/pep-0008/), overridden by any specific naming conventions recommended by the [blender python API](https://docs.blender.org/api/current/index.html):

--- a/docs/send2ue/preferences/export.md
+++ b/docs/send2ue/preferences/export.md
@@ -27,7 +27,7 @@ This automatically scales your armature objects so they import at scale of 1
 
 #### Export all actions
 
-This setting ensures that regardless of the mute values on your NLA tracks, your actions will get exported. It does this by un-muting all NLA tracks before the FBX export.
+This setting ensures that regardless of the mute values or the solo value (star) on your NLA tracks, your actions will get exported. It does this by un-muting all NLA tracks before the FBX export.
 
 #### Auto stash active action
 

--- a/send2ue/addon/__init__.py
+++ b/send2ue/addon/__init__.py
@@ -15,7 +15,7 @@ from .functions import export, unreal, validations, utilities
 bl_info = {
     "name": "Send to Unreal",
     "author": "Epic Games Inc.",
-    "version": (1, 8, 3),   # addon plugin version
+    "version": (1, 8, 4),   # addon plugin version
     "blender": (2, 83, 0),  # minimum blender version
     "location": "Header > Pipeline > Export > Send to Unreal",
     "description": "Sends an asset to the first open Unreal Editor instance on your machine.",

--- a/send2ue/addon/operators.py
+++ b/send2ue/addon/operators.py
@@ -28,7 +28,7 @@ class AdvancedSend2Ue(bpy.types.Operator):
 
     def invoke(self, context, event):
         wm = context.window_manager
-        return wm.invoke_props_dialog(self)
+        return wm.invoke_props_dialog(self, width=600)
 
     def draw(self, context):
         # uses property group from

--- a/send2ue/addon/properties.py
+++ b/send2ue/addon/properties.py
@@ -139,8 +139,8 @@ class Send2UeUIProperties:
         name="Export all actions",
         default=True,
         description=(
-            "This setting ensures that regardless of the mute values on your NLA tracks, your actions will get "
-            "exported. It does this by un-muting all NLA tracks before the FBX export"
+            "This setting ensures that regardless of the mute values or the solo value (star) on your NLA tracks, your "
+            "actions will get exported. It does this by un-muting all NLA tracks before the FBX export"
         )
     )
     auto_stash_active_action: bpy.props.BoolProperty(
@@ -266,7 +266,7 @@ class Send2UeUIProperties:
     # ---------------------------- name affix settings --------------------------------
     auto_add_asset_name_affixes: bpy.props.BoolProperty(
         name="Automatically add affixes on export",
-        description= (
+        description=(
             "Whether or not to add the affixes (prefix, suffix) to the asset names before the export. "
             "Prefixes end with an underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
         ),
@@ -274,7 +274,7 @@ class Send2UeUIProperties:
     )
     auto_remove_original_asset_names: bpy.props.BoolProperty(
         name="Remove affixes after export",
-        description= (
+        description=(
             "Whether or not to remove the affixes (prefix, suffix) from the asset names after the export, "
             + "basically restoring the original names."
         ),
@@ -285,35 +285,35 @@ class Send2UeUIProperties:
         default="SM_",
         update=validations.validate_asset_affixes,
         description="The prefix or suffix to use for exported static mesh assets. Prefixes end with an "
-            "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
+                    "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
     )
     material_name_affix: bpy.props.StringProperty(
         name="Material Affix",
         default="M_",
         update=validations.validate_asset_affixes,
         description="The prefix or suffix to use for exported material assets. Prefixes end with an "
-            "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
+                    "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
     )
     texture_name_affix: bpy.props.StringProperty(
         name="Texture Affix",
         default="T_",
         update=validations.validate_asset_affixes,
         description="The prefix or suffix to use for exported texture assets. Prefixes end with an "
-            "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
+                    "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
     )
     skeletal_mesh_name_affix: bpy.props.StringProperty(
         name="Skeletal Mesh Affix",
         default="SK_",
         update=validations.validate_asset_affixes,
         description="The prefix or suffix to use for exported skeletal mesh assets. Prefixes end with an "
-            "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
-    )    
+                    "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
+    )
     animation_sequence_name_affix: bpy.props.StringProperty(
         name="Animation Sequence Affix",
         default="Anim_",
         update=validations.validate_asset_affixes,
         description="The prefix or suffix to use for exported animation sequence assets. Prefixes end with an "
-            "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
+                    "underscore (e.g. Prefix_) and suffixes start with an underscore (e.g. _Suffix)"
     )
 
     # ---------------------------- fbx file settings --------------------------------

--- a/send2ue/addon/ui/addon_preferences.py
+++ b/send2ue/addon/ui/addon_preferences.py
@@ -177,14 +177,14 @@ def draw_export_tab(properties, layout):
     box = row.box()
     row = box.row()
     row.prop(
-            properties,
-            'show_name_affix_settings',
-            icon='TRIA_DOWN' if properties.show_name_affix_settings else 'TRIA_RIGHT',
-            icon_only=True,
-            emboss=False
-        )
+        properties,
+        'show_name_affix_settings',
+        icon='TRIA_DOWN' if properties.show_name_affix_settings else 'TRIA_RIGHT',
+        icon_only=True,
+        emboss=False
+    )
     row.label(text='Asset Name Affixes', icon='SYNTAX_OFF')
-    
+
     if properties.show_name_affix_settings:
         draw_asset_affix_settings(properties, box)
 
@@ -278,57 +278,56 @@ def draw_asset_affix_settings(properties, layout):
     row.prop(properties, 'auto_add_asset_name_affixes')
     if properties.auto_add_asset_name_affixes:
         row.label(text='Warning: This will rename the exported assets in Blender!',
-            icon='ERROR')
+                  icon='ERROR')
     # Automatically Remove Asset Affixes after export
     row = layout.row()
     row.prop(properties, 'auto_remove_original_asset_names')
-
 
     # Static Mesh Affix
     row = layout.row()
     row.alert = properties.incorrect_static_mesh_name_affix
     row.prop(properties, 'static_mesh_name_affix')
     utilities.report_path_error_message(
-            layout,
-            properties.incorrect_static_mesh_name_affix,
-            validations.show_asset_affix_message(properties, 'incorrect_static_mesh_name_affix')
-        )
+        layout,
+        properties.incorrect_static_mesh_name_affix,
+        validations.show_asset_affix_message(properties, 'incorrect_static_mesh_name_affix')
+    )
     # Material Affix
     row = layout.row()
     row.alert = properties.incorrect_material_name_affix
     row.prop(properties, 'material_name_affix')
     utilities.report_path_error_message(
-            layout,
-            properties.incorrect_material_name_affix,
-            validations.show_asset_affix_message(properties, 'incorrect_material_name_affix')
-        )
+        layout,
+        properties.incorrect_material_name_affix,
+        validations.show_asset_affix_message(properties, 'incorrect_material_name_affix')
+    )
     # Texture Affix
     row = layout.row()
     row.alert = properties.incorrect_texture_name_affix
     row.prop(properties, 'texture_name_affix')
     utilities.report_path_error_message(
-            layout,
-            properties.incorrect_texture_name_affix,
-            validations.show_asset_affix_message(properties, 'incorrect_texture_name_affix')
-        )
+        layout,
+        properties.incorrect_texture_name_affix,
+        validations.show_asset_affix_message(properties, 'incorrect_texture_name_affix')
+    )
     # Skeletal Mesh Affix
     row = layout.row()
     row.alert = properties.incorrect_skeletal_mesh_name_affix
     row.prop(properties, 'skeletal_mesh_name_affix')
     utilities.report_path_error_message(
-            layout,
-            properties.incorrect_skeletal_mesh_name_affix,
-            validations.show_asset_affix_message(properties, 'incorrect_skeletal_mesh_name_affix')
-        )
+        layout,
+        properties.incorrect_skeletal_mesh_name_affix,
+        validations.show_asset_affix_message(properties, 'incorrect_skeletal_mesh_name_affix')
+    )
     # Animation Sequence Affix
     row = layout.row()
     row.alert = properties.incorrect_animation_sequence_name_affix
     row.prop(properties, 'animation_sequence_name_affix')
     utilities.report_path_error_message(
-            layout,
-            properties.incorrect_animation_sequence_name_affix,
-            validations.show_asset_affix_message(properties, 'incorrect_animation_sequence_name_affix')
-        )
+        layout,
+        properties.incorrect_animation_sequence_name_affix,
+        validations.show_asset_affix_message(properties, 'incorrect_animation_sequence_name_affix')
+    )
 
 
 def draw_fbx_box(properties, layout):

--- a/test/unit_tests/send2ue_nla_options.py
+++ b/test/unit_tests/send2ue_nla_options.py
@@ -11,7 +11,6 @@ class Send2UeNlaOptionsTestCases(unittest.TestCase):
     https://github.com/EpicGames/BlenderTools/issues/99
     This class checks all the export options related to the NLA strips.
     """
-
     def setUp(self):
         # load in the file you will run tests on
         bpy.ops.wm.open_mainfile(filepath=os.path.join(os.environ['BLENDS'], 'skeletal_meshes.blend'))
@@ -66,14 +65,11 @@ class Send2UeNlaOptionsTestCases(unittest.TestCase):
             '/Game/untitled_category/untitled_asset/animations/third_person_walk_01'
         ))
 
-        # delete all the assets created by the import
-        unreal_utilities.delete_directory('/Game/untitled_category/untitled_asset')
-
     def test_export_all_actions_false(self):
         """
         This method tests that only un-muted animations are exported when export_all_actions is set to false.
         """
-        properties = properties = bpy.context.preferences.addons['send2ue'].preferences
+        properties = bpy.context.preferences.addons['send2ue'].preferences
         properties.export_all_actions = False
         properties.auto_stash_active_action = True
         properties.auto_sync_control_nla_to_source = True
@@ -101,14 +97,11 @@ class Send2UeNlaOptionsTestCases(unittest.TestCase):
             '/Game/untitled_category/untitled_asset/animations/third_person_walk_01'
         ))
 
-        # delete all the assets created by the import
-        unreal_utilities.delete_directory('/Game/untitled_category/untitled_asset')
-
     def test_auto_sync_control_nla_to_source_false(self):
         """
         This method tests that no animations are synced over when auto_sync_control_nla_to_source is set to false.
         """
-        properties = properties = bpy.context.preferences.addons['send2ue'].preferences
+        properties = bpy.context.preferences.addons['send2ue'].preferences
         properties.export_all_actions = True
         properties.auto_stash_active_action = True
         properties.auto_sync_control_nla_to_source = False
@@ -144,8 +137,78 @@ class Send2UeNlaOptionsTestCases(unittest.TestCase):
             '/Game/untitled_category/untitled_asset/animations/third_person_walk_01'
         ))
 
-        # delete all the assets created by the import
-        unreal_utilities.delete_directory('/Game/untitled_category/untitled_asset')
-
         # revert the source rig back to a control rig
         bpy.ops.ue2rigify.revert_to_source_rig()
+
+    def test_export_solo_action(self):
+        """
+        This method tests that if a NLA track is starred that only that track's action is exported.
+        """
+        properties = bpy.context.preferences.addons['send2ue'].preferences
+        properties.export_all_actions = False
+        properties.auto_stash_active_action = True
+        properties.auto_sync_control_nla_to_source = True
+
+        source_rig = bpy.data.objects['root']
+
+        # set the walk animation to solo
+        source_rig.animation_data.nla_tracks['third_person_run_01'].is_solo = True
+
+        # run the send to unreal operation
+        bpy.ops.wm.send2ue()
+
+        # check if the mannequin skeletal mesh exists in the unreal project
+        self.assertTrue(unreal_utilities.asset_exists('/Game/untitled_category/untitled_asset/SK_Mannequin'))
+
+        # check if the mannequin skeleton exists in the unreal project
+        self.assertTrue(unreal_utilities.asset_exists('/Game/untitled_category/untitled_asset/SK_Mannequin_Skeleton'))
+
+        # check if the run animation exists in the unreal project
+        self.assertTrue(unreal_utilities.asset_exists(
+            '/Game/untitled_category/untitled_asset/animations/third_person_run_01'
+        ))
+        # check if the walk animation exists in the unreal project
+        self.assertFalse(unreal_utilities.asset_exists(
+            '/Game/untitled_category/untitled_asset/animations/third_person_walk_01'
+        ))
+
+    def test_export_control_rig_solo_action(self):
+        """
+        This method tests that if a NLA track is starred on the control rig that only that track's action is exported.
+        """
+        properties = bpy.context.preferences.addons['send2ue'].preferences
+        properties.export_all_actions = False
+        properties.auto_stash_active_action = True
+        properties.auto_sync_control_nla_to_source = True
+
+        # unfreeze the rig
+        bpy.context.window_manager.ue2rigify.freeze_rig = False
+
+        # set the source rig
+        bpy.context.window_manager.ue2rigify.source_rig_name = 'root'
+
+        # convert the source rig to a control rig
+        bpy.ops.ue2rigify.convert_to_control_rig()
+
+        control_rig = bpy.data.objects['rig']
+
+        # set the walk animation to solo
+        control_rig.animation_data.nla_tracks['third_person_run_01'].is_solo = True
+
+        # run the send to unreal operation
+        bpy.ops.wm.send2ue()
+
+        # check if the mannequin skeletal mesh exists in the unreal project
+        self.assertTrue(unreal_utilities.asset_exists('/Game/untitled_category/untitled_asset/SK_Mannequin'))
+
+        # check if the mannequin skeleton exists in the unreal project
+        self.assertTrue(unreal_utilities.asset_exists('/Game/untitled_category/untitled_asset/SK_Mannequin_Skeleton'))
+
+        # check if the run animation exists in the unreal project
+        self.assertTrue(unreal_utilities.asset_exists(
+            '/Game/untitled_category/untitled_asset/animations/third_person_run_01'
+        ))
+        # check if the walk animation exists in the unreal project
+        self.assertFalse(unreal_utilities.asset_exists(
+            '/Game/untitled_category/untitled_asset/animations/third_person_walk_01'
+        ))

--- a/ue2rigify/addon/__init__.py
+++ b/ue2rigify/addon/__init__.py
@@ -14,7 +14,7 @@ bl_info = {
     "author": "Epic Games Inc.",
     "description": "Allows you to convert a given rig and its animations to a Rigify rig.",
     "blender": (2, 83, 0),
-    "version": (1, 5, 7),
+    "version": (1, 5, 8),
     "location": "3D View > Tools > UE to Rigify",
     "wiki_url": "https://epicgames.github.io/BlenderTools/ue2rigify/quickstart.html",
     "warning": "",


### PR DESCRIPTION
Affixes can now be added to assets with a utility operator, or automatically before the send to unreal operation to enforce naming conventions. (Thanks to @zaha for adding this feature)
#282

Individual actions can now be exported by starring NLA tracks when 'Export all actions' is turned off
#296

fixed 'Combine child meshes' along with custom collision bug
#285

Fixed sockets being moved to center bug
#69