### PR TITLE
Update templates.py

### DIFF
--- a/ue2rigify/addon/functions/templates.py
+++ b/ue2rigify/addon/functions/templates.py
@@ -24,7 +24,7 @@ def get_rig_templates_path():
 
     :return str: The full path to the addons rig template directory.
     """
-    addons = bpy.utils.user_resource('SCRIPTS', 'addons')
+    addons = bpy.utils.user_resource('SCRIPTS', path='addons')
     return os.path.join(addons, __package__.split('.')[0], 'resources', 'rig_templates')
 
 


### PR DESCRIPTION
Added the keyword for the path that is now required in Blender 3.0

Tested in 2.93 and seemed fine there as well.

A fix for this issue
https://github.com/EpicGames/BlenderTools/issues/349
