### PR TITLE
Update documentation to state where ue2rigify stores new templates

### DIFF
--- a/docs/ue2rigify/trouble-shooting/faq.md
+++ b/docs/ue2rigify/trouble-shooting/faq.md
@@ -11,3 +11,7 @@ it. You should stay away from the names "metarig" and "rig" because those are Ri
 Rigify generates a new rigify rig, those could get stomped on. Thus, renaming the metarig you added as your source
 rig is necessary for this to work.
 
+## Where are Rig templates stored?
+Rig templates are stored within:
+- windows: `%TEMP%\ue2rigify\resources\rig_templates`
+- unix: `/tmp/ue2rigify/resources/rig_templates`

--- a/docs/ue2rigify/user-interface/3d-view-panel.md
+++ b/docs/ue2rigify/user-interface/3d-view-panel.md
@@ -17,7 +17,9 @@ This object picker specifies which object is the ‘Source’ rig.
 
 ### Template
 
-This dropdown allows you to select a template or create a new one.
+This dropdown allows you to select a template or create a new one. New templates are stored within:
+- windows: `%TEMP%\ue2rigify\resources\rig_templates`
+- unix: `/tmp/ue2rigify/resources/rig_templates`
 
 
 ### Mode


### PR DESCRIPTION
# What was changed

The ue2rigify documentation now makes mention of where newly created templates are found

# Why it was changed

The "Create New" button, with "male_mannequin" metarig selected, does not create FK and Deform Bone re-mapping nodes for you. In this case, it is useful to copy the "male_mannequin" template folder (for example) and rename it, so you can make your tweaks on this version instead. This avoids users editing the templates that come ootb.

# Note

The path may be different on Linux or MAC OS, therefore, it may be worth adding a list of locations (Windows: ... Linux: ..., MacOS: ...),  or a more general note about where you may find the templates.