### PR TITLE
Send to Unreal 2.1.0

### DIFF
--- a/docs/main/contributing/documentation.md
+++ b/docs/main/contributing/documentation.md
@@ -27,7 +27,7 @@ Once you have node and npm installed switch to the `/docs` folder and start the 
 running these commands:
 
 ``` shell
-cd /docs
+cd ./docs
 npm install
 npm run dev-main
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-docker==5.0.3
+docker
 unittest-xml-reporting==3.2.0
 fake-bpy-module-latest==20220324

--- a/send2ue/__init__.py
+++ b/send2ue/__init__.py
@@ -13,7 +13,7 @@ from .core import formatting, validations, settings, utilities, export, ingest, 
 bl_info = {
     "name": "Send to Unreal",
     "author": "Epic Games Inc.",
-    "version": (2, 0, 2),
+    "version": (2, 1, 0),
     "blender": (2, 93, 0),
     "location": "Header > Pipeline > Send to Unreal",
     "description": "Sends an asset to the first open Unreal Editor instance on your machine.",
@@ -57,11 +57,6 @@ def register():
         # register the operators
         operators.register()
 
-        # add extensions
-        extension_factory = extension.ExtensionFactory()
-        extension_factory.create_operators()
-        extension_factory.create_draws()
-
         # register the header menu
         header_menu.register()
 
@@ -94,12 +89,6 @@ def unregister():
 
         # register the addon preferences
         addon_preferences.unregister()
-
-        # remove extensions
-        extension_factory = extension.ExtensionFactory()
-        extension_factory.remove_draws()
-        extension_factory.remove_operators()
-        extension_factory.remove_property_data()
 
         # unregister the operators
         operators.unregister()

--- a/send2ue/constants.py
+++ b/send2ue/constants.py
@@ -31,25 +31,27 @@ class ToolInfo(Enum):
 
 class Template:
     NAME = 'templates'
-    IGNORED_PROPERTIES = ['asset_id', 'asset_data', 'validations_passed', 'active_settings_template']
+    IGNORED_PROPERTIES = ['active_settings_template']
     DEFAULT = 'default.json'
     VERSION = 1
 
 
 class Extensions:
     NAME = 'extensions'
-    UTILITY_OPERATOR = 'util_op'
     DRAW_NAMESPACE = f'{ToolInfo.NAME.value}_{NAME}_'
     DRAW_TABS = ['draw_export', 'draw_import', 'draw_validations']
     FOLDER = os.path.join(ToolInfo.RESOURCE_FOLDER.value, NAME)
 
 
-class ExtensionOperators(Enum):
+class ExtensionTasks(Enum):
     PRE_OPERATION = 'pre_operation'
     PRE_VALIDATIONS = 'pre_validations'
     POST_VALIDATIONS = 'post_validations'
     PRE_ANIMATION_EXPORT = 'pre_animation_export'
     POST_ANIMATION_EXPORT = 'post_animation_export'
+    PRE_BONE_SCALE = 'pre_bone_scale'
+    MID_BONE_SCALE = 'mid_bone_scale'
+    POST_BONE_SCALE = 'post_bone_scale'
     PRE_MESH_EXPORT = 'pre_mesh_export'
     POST_MESH_EXPORT = 'post_mesh_export'
     PRE_IMPORT = 'pre_import'

--- a/send2ue/core/formatting.py
+++ b/send2ue/core/formatting.py
@@ -184,16 +184,16 @@ def auto_format_unreal_asset_path(name, properties):
         if value != formatted_value:
             setattr(properties, name, formatted_value)
 
-            # Ensure unreal editor is open
-            if not is_connected():
-                error_message = (
-                    f'No Unreal Editor connection. Asset path "{formatted_value}" can not be validated.'
-                )
-                set_property_error_message(
-                    name,
-                    error_message
-                )
-                return error_message
+        # Ensure unreal editor is open
+        if not is_connected():
+            error_message = (
+                f'No Unreal Editor connection. Asset path "{formatted_value}" can not be validated.'
+            )
+            set_property_error_message(
+                name,
+                error_message
+            )
+            return error_message
 
         if not error_message and not UnrealRemoteCalls.asset_exists(formatted_value):
             error_message = f'Asset "{formatted_value}" does not exist in unreal.'

--- a/send2ue/core/ingest.py
+++ b/send2ue/core/ingest.py
@@ -1,28 +1,25 @@
 # Copyright Epic Games, Inc. All Rights Reserved.
 
+import bpy
 from . import settings, extension
-from ..constants import PathModes, ExtensionOperators
+from ..constants import PathModes, ExtensionTasks
 from ..dependencies.unreal import UnrealRemoteCalls
 from .utilities import track_progress, get_asset_id
 
 
 @track_progress(message='Importing asset "{attribute}"...', attribute='file_path')
-def import_asset(asset_id, properties, property_data):
+def import_asset(asset_id, property_data):
     """
     Imports an asset to unreal based on the asset data in the provided dictionary.
 
     :param str asset_id: The unique id of the asset.
-    :param PropertyData properties: A property data instance that contains all property values of the tool.
     :param dict property_data: A dictionary representation of the properties.
     """
-    # set the current asset id
-    properties.asset_id = asset_id
-
     # run the pre import extensions
-    extension.run_operators(ExtensionOperators.PRE_IMPORT.value)
+    extension.run_extension_tasks(ExtensionTasks.PRE_IMPORT.value)
 
     # get the asset data
-    asset_data = properties.asset_data[properties.asset_id]
+    asset_data = bpy.context.window_manager.send2ue.asset_data[asset_id]
 
     # import the asset
     UnrealRemoteCalls.import_asset(asset_data.get('file_path'), asset_data, property_data)
@@ -35,18 +32,17 @@ def import_asset(asset_id, properties, property_data):
         )
 
     # run the post import extensions
-    extension.run_operators(ExtensionOperators.POST_IMPORT.value)
+    extension.run_extension_tasks(ExtensionTasks.POST_IMPORT.value)
 
 
 @track_progress(message='Creating static mesh sockets for "{attribute}"...', attribute='asset_path')
-def create_static_mesh_sockets(asset_id, properties):
+def create_static_mesh_sockets(asset_id):
     """
     Creates sockets on a static mesh.
 
     :param str asset_id: The unique id of the asset.
-    :param PropertyData properties: A property data instance that contains all property values of the tool.
     """
-    asset_data = properties.asset_data[asset_id]
+    asset_data = bpy.context.window_manager.send2ue.asset_data[asset_id]
     UnrealRemoteCalls.set_static_mesh_sockets(
         asset_data.get('asset_path'),
         asset_data
@@ -54,15 +50,14 @@ def create_static_mesh_sockets(asset_id, properties):
 
 
 @track_progress(message='Resetting lods for "{attribute}"...', attribute='asset_path')
-def reset_lods(asset_id, properties, property_data):
+def reset_lods(asset_id, property_data):
     """
     Removes all lods on the given mesh.
 
     :param str asset_id: The unique id of the asset.
-    :param PropertyData properties: A property data instance that contains all property values of the tool.
     :param dict property_data: A dictionary representation of the properties.
     """
-    asset_data = properties.asset_data[asset_id]
+    asset_data = bpy.context.window_manager.send2ue.asset_data[asset_id]
     asset_path = asset_data.get('asset_path')
 
     if asset_data.get('skeletal_mesh'):
@@ -72,14 +67,13 @@ def reset_lods(asset_id, properties, property_data):
 
 
 @track_progress(message='Importing lods for "{attribute}"...', attribute='asset_path')
-def import_lod_files(asset_id, properties):
+def import_lod_files(asset_id):
     """
     Imports lods onto a mesh.
 
     :param str asset_id: The unique id of the asset.
-    :param PropertyData properties: A property data instance that contains all property values of the tool.
     """
-    asset_data = properties.asset_data[asset_id]
+    asset_data = bpy.context.window_manager.send2ue.asset_data[asset_id]
     lods = asset_data.get('lods', {})
     for index in range(1, len(lods.keys()) + 1):
         lod_file_path = lods.get(str(index))
@@ -90,15 +84,14 @@ def import_lod_files(asset_id, properties):
 
 
 @track_progress(message='Setting lod build settings for "{attribute}"...', attribute='asset_path')
-def set_lod_build_settings(asset_id, properties, property_data):
+def set_lod_build_settings(asset_id, property_data):
     """
     Sets the lod build settings.
 
     :param str asset_id: The unique id of the asset.
-    :param PropertyData properties: A property data instance that contains all property values of the tool.
     :param dict property_data: A dictionary representation of the properties.
     """
-    asset_data = properties.asset_data[asset_id]
+    asset_data = bpy.context.window_manager.send2ue.asset_data[asset_id]
     lods = asset_data.get('lods', {})
     for index in range(0, len(lods.keys()) + 1):
         if asset_data.get('skeletal_mesh'):
@@ -115,13 +108,13 @@ def set_lod_build_settings(asset_id, properties, property_data):
             )
 
 
-def asset(properties):
+def assets(properties):
     """
-    Ingests an asset.
+    Ingests the assets.
 
     :param PropertyData properties: A property data instance that contains all property values of the tool.
     """
-    if properties.asset_data:
+    if bpy.context.window_manager.send2ue.asset_data:
         property_data = settings.get_extra_property_group_data_as_dictionary(properties, only_key='unreal_type')
 
         # check path mode to see if exported assets should be imported to unreal
@@ -129,19 +122,19 @@ def asset(properties):
             PathModes.SEND_TO_PROJECT.value,
             PathModes.SEND_TO_DISK_THEN_PROJECT.value
         ]:
-            for asset_data in properties.asset_data.values():
+            for asset_data in bpy.context.window_manager.send2ue.asset_data.values():
                 # get the asset id
                 asset_id = get_asset_id(asset_data.get('file_path'))
 
                 # imports static mesh, skeletal mesh or animation
-                import_asset(asset_id, properties, property_data)
+                import_asset(asset_id, property_data)
 
                 # import lods
                 if asset_data.get('lods'):
-                    reset_lods(asset_id, properties, property_data)
-                    import_lod_files(asset_id, properties)
-                    set_lod_build_settings(asset_id, properties, property_data)
+                    reset_lods(asset_id, property_data)
+                    import_lod_files(asset_id)
+                    set_lod_build_settings(asset_id, property_data)
 
                 # import sockets
                 if asset_data.get('sockets'):
-                    create_static_mesh_sockets(asset_id, properties)
+                    create_static_mesh_sockets(asset_id)

--- a/send2ue/core/validations.py
+++ b/send2ue/core/validations.py
@@ -3,9 +3,9 @@
 import re
 import os
 import bpy
-from . import utilities, formatting
+from . import utilities, formatting, extension
 from ..dependencies.unreal import UnrealRemoteCalls
-from ..constants import AssetTypes, PathModes, ToolInfo, Extensions, ExtensionOperators
+from ..constants import AssetTypes, PathModes, ToolInfo, Extensions, ExtensionTasks
 
 
 class ValidationManager:
@@ -24,35 +24,47 @@ class ValidationManager:
         """
         Registers all method in this class that start with `validate`.
         """
+
         for attribute in dir(self):
             if attribute.startswith('validate_'):
                 validator = getattr(self, attribute)
                 self._validators.append(validator)
 
-        # add in any validations defined in the extensions
-        operator_namespace = getattr(bpy.ops, ToolInfo.NAME.value, None)
-        if operator_namespace:
-            for attribute in dir(operator_namespace):
-                if attribute.startswith(f'{Extensions.NAME}_'):
-                    validation_operator = getattr(operator_namespace, attribute)
-                    if attribute.endswith(f'_{ExtensionOperators.PRE_VALIDATIONS.value}'):
-                        self._validators.insert(0, validation_operator)
-                    if attribute.endswith(f'_{ExtensionOperators.POST_VALIDATIONS.value}'):
-                        self._validators.append(validation_operator)
-
     def run(self):
         """
         Run the registered validations.
         """
-        self.properties.validations_passed = True
+        # run any pre validations defined in the extensions
+        for attribute in dir(bpy.context.scene.send2ue.extensions):
+            pre_validations = getattr(getattr(
+                bpy.context.scene.send2ue.extensions, attribute, object),
+                ExtensionTasks.PRE_VALIDATIONS.value,
+                None
+            )
+            if pre_validations:
+                if not pre_validations(self.properties):
+                    return False
+
+        # run the core validations
         for validator in self._validators:
-            if self.properties.validations_passed:
-                validator()
-            else:
+            if not validator():
                 return False
+
+        # run any post validations defined in the extensions
+        for attribute in dir(bpy.context.scene.send2ue.extensions):
+            post_validations = getattr(getattr(
+                bpy.context.scene.send2ue.extensions, attribute, object),
+                ExtensionTasks.POST_VALIDATIONS.value,
+                None
+            )
+            if post_validations:
+                if not post_validations(self.properties):
+                    return False
+
         return True
 
-    def validate_collections_exist(self):
+    @staticmethod
+    def validate_collections_exist():
         """
         Checks the scene to make sure the appropriate collections exist.
         """
@@ -62,7 +74,8 @@ class ValidationManager:
                 utilities.report_error(
                     f'You do not have a collection "{collection_name}" in your outliner. Please create it.'
                 )
-                self.properties.validations_passed = False
+                return False
+        return True
 
     def validate_asset_data_exists(self):
         """
@@ -77,7 +90,8 @@ class ValidationManager:
                 utilities.report_error(
                     f'You do not have any objects under the "{ToolInfo.EXPORT_COLLECTION.value}" collection!'
                 )
-                self.properties.validations_passed = False
+                return False
+        return True
 
     def validate_object_names(self):
         """
@@ -89,7 +103,8 @@ class ValidationManager:
                 utilities.report_error(
                     f'Object "{scene_object.name}" has an invalid name. Please rename it.'
                 )
-                self.properties.validations_passed = False
+                return False
+        return True
 
     def validate_geometry_exists(self):
         """
@@ -99,7 +114,8 @@ class ValidationManager:
             # check if vertices exist
             if len(mesh_object.data.vertices) <= 0:
                 utilities.report_error(f'Mesh "{mesh_object.name}" has no geometry.')
-                self.properties.validations_passed = False
+                return False
+        return True
 
     def validate_scene_scale(self):
         """
@@ -112,7 +128,8 @@ class ValidationManager:
                     f'The scene scale "{length_unit}" is not recommended. Please change to '
                     f'"{self.properties.validate_scene_scale}", or disable this validation.'
                 )
-                self.properties.validations_passed = False
+                return False
+        return True
 
     def validate_scene_frame_rate(self):
         """
@@ -126,7 +143,8 @@ class ValidationManager:
                     f'"{self.properties.validate_time_units}" in your render settings before continuing, '
                     f'or disable this validation.'
                 )
-                self.properties.validations_passed = False
+                return False
+        return True
 
     def validate_disk_folders(self):
         """
@@ -146,8 +164,8 @@ class ValidationManager:
                     error_message = formatting.auto_format_disk_folder_path(property_name, self.properties)
                     if error_message:
                         utilities.report_error(error_message)
-                        self.properties.validations_passed = False
-                        return
+                        return False
+        return True
 
     def validate_unreal_folders(self):
         """
@@ -166,8 +184,8 @@ class ValidationManager:
                     error_message = formatting.auto_format_unreal_folder_path(property_name, self.properties)
                     if error_message:
                         utilities.report_error(error_message)
-                        self.properties.validations_passed = False
-                        return
+                        return False
+        return True
 
     def validate_unreal_asset_paths(self):
         """
@@ -188,8 +206,8 @@ class ValidationManager:
                     error_message = formatting.auto_format_unreal_asset_path(property_name, self.properties)
                     if error_message:
                         utilities.report_error(error_message)
-                        self.properties.validations_passed = False
-                        return
+                        return False
+        return True
 
     def validate_materials(self):
         """
@@ -212,8 +230,8 @@ class ValidationManager:
                     if material_slots:
                         for material_slot in material_slots:
                             utilities.report_error(f'Mesh "{mesh_object.name}" has a unused material "{material_slot}"')
-                            self.properties.validations_passed = False
-                            return
+                            return False
+        return True
 
     def validate_lod_names(self):
         """
@@ -227,8 +245,8 @@ class ValidationManager:
                         f'Object "{mesh_object.name}" does not follow the correct lod naming convention defined in the'
                         f'import setting by the lod regex.'
                     )
-                    self.properties.validations_passed = False
-                    return
+                    return False
+        return True
 
     def validate_texture_references(self):
         """
@@ -250,8 +268,8 @@ class ValidationManager:
                                         f'Mesh "{mesh_object.name}" has a material "{material_slot.material.name}" that '
                                         f'contains a missing image "{node.image.name}".'
                                     )
-                                    self.properties.validations_passed = False
-                                    return
+                                    return False
+        return True
 
     def validate_object_root_scale(self):
         """
@@ -270,5 +288,5 @@ class ValidationManager:
                         f'"{scene_object.name}" has un-applied transforms "{", ".join(non_zero_transforms)}". These must '
                         f'be zero to avoid unexpected results. Otherwise, turn off this validation to ignore.'
                     )
-                    self.properties.validations_passed = False
-                    return
+                    return False
+        return True

--- a/send2ue/properties.py
+++ b/send2ue/properties.py
@@ -38,6 +38,15 @@ class Send2UeWindowMangerProperties(bpy.types.PropertyGroup):
     """
     This class holds the properties for a window.
     """
+    # ------------- current asset info ------------------
+    asset_data = {}
+    asset_id: bpy.props.StringProperty(
+        default='',
+        description=(
+            'Holds the current asset id. This can be used in an extension method to access and modify specific '
+            'asset data'
+        )
+    )
     # ----------- read/write dictionaries -----------
     property_errors = {}
     section_collapse_states = {}
@@ -85,30 +94,12 @@ def get_scene_property_class():
     """
     # the extension factory will add in the extension properties
     extension_factory = extension.ExtensionFactory()
-    property_class = extension_factory.get_properties()
+    property_class = extension_factory.get_property_group_class()
 
     class Send2UeSceneProperties(property_class):
         """
         This class holds the properties for the scene.
         """
-        # ------------- current asset info ------------------
-        asset_data = {}
-        asset_id: bpy.props.StringProperty(
-            default='',
-            description=(
-                'Holds the current asset id. This can be used in an extension method to access and modify specific '
-                'asset data'
-            )
-        )
-        validations_passed: bpy.props.BoolProperty(
-            default=True,
-            description=(
-                'Holds the current passing state of the validations, if set the false all processes will terminate. '
-                'This is useful for extensions that need to read or modify this'
-            )
-        )
-        # --------------------------------------------------
-
         # track the template version
         template_version: bpy.props.FloatProperty(
             name='Template Version',
@@ -525,6 +516,10 @@ def unregister():
     Unregisters the property group class and deletes it from the window manager context when the
     addon is disabled.
     """
+
+    # remove the extension property data
+    extension_factory = extension.ExtensionFactory()
+    extension_factory.remove_property_data()
     unregister_scene_properties()
 
     window_manager_property_class = bpy.types.PropertyGroup.bl_rna_get_subclass_py('Send2UeWindowMangerProperties')

--- a/send2ue/resources/extensions/ue2rigify.py
+++ b/send2ue/resources/extensions/ue2rigify.py
@@ -8,7 +8,7 @@ from send2ue.core import utilities
 class Ue2RigifyExtension(ExtensionBase):
     name = 'ue2rigify'
 
-    def pre_validations(self):
+    def pre_validations(self, properties):
         """
         Defines the pre validation logic that will be an injected operation.
         """
@@ -19,4 +19,5 @@ class Ue2RigifyExtension(ExtensionBase):
                     'Send to Unreal can not be used while UE to Rigify is in not in source mode. All '
                     'animations must be baked to the source rig then try again.'
                 )
-                self.validations_passed = False
+                return False
+        return True

--- a/send2ue/resources/settings.json
+++ b/send2ue/resources/settings.json
@@ -9,6 +9,12 @@
           "default": false
         },
         "static_mesh_import_data": {
+          "build_nanite": {
+            "name": "Build Nanite",
+            "description": "If enabled, allows to render objects with Nanite",
+            "type": "BOOLEAN",
+            "default": false
+          },
           "auto_generate_collision": {
             "name": "Generate Missing Collision",
             "description": "If checked, collision will automatically be generated (ignored if custom collision is imported or used)",
@@ -714,7 +720,7 @@
         },
         "texture_import_data": {
           "material_search_location": {
-            "name": "Search Location",
+            "name": "Material Import Method",
             "description": "Specify where we should search for matching materials when importing",
             "enum_items": [
               [
@@ -1251,7 +1257,7 @@
               ]
             ],
             "type": "ENUM",
-            "default": "OFF"
+            "default": "FACE"
           },
           "use_subsurf": {
             "name": "Export Subdivision Surface",

--- a/send2ue/ui/dialog.py
+++ b/send2ue/ui/dialog.py
@@ -2,7 +2,7 @@
 
 import bpy
 from ..constants import PathModes, Extensions, Template
-from ..core import validations, utilities, settings
+from ..core import utilities, settings
 
 
 class Send2UnrealDialog(bpy.types.Panel):
@@ -249,9 +249,11 @@ class Send2UnrealDialog(bpy.types.Panel):
         Draws the draws of each extension.
         """
         properties = bpy.context.scene.send2ue
-        for name, function in bpy.app.driver_namespace.items():
-            if name.startswith(Extensions.DRAW_NAMESPACE) and name.endswith(f'_draw_{properties.tab}'):
-                function(properties, self, layout)
+        for extension_name in dir(properties.extensions):
+            extension = getattr(properties.extensions, extension_name)
+            draw = getattr(extension, f'draw_{properties.tab}', None)
+            if draw:
+                draw(self, layout, properties)
 
     def draw_animation_settings(self, layout):
         """

--- a/send2ue/ui/header_menu.py
+++ b/send2ue/ui/header_menu.py
@@ -1,6 +1,5 @@
 # Copyright Epic Games, Inc. All Rights Reserved.
 import bpy
-from ..core import utilities
 from ..constants import ToolInfo, Extensions
 
 
@@ -41,7 +40,7 @@ class TOPBAR_MT_Utilities(bpy.types.Menu):
         operator_namespace = getattr(bpy.ops, ToolInfo.NAME.value, None)
         if operator_namespace:
             for namespace in dir(operator_namespace):
-                if namespace.startswith(f'{Extensions.NAME}_') and f'_{Extensions.UTILITY_OPERATOR}' in namespace:
+                if namespace.startswith(f'{Extensions.NAME}_'):
                     self.layout.operator(f'{ToolInfo.NAME.value}.{namespace}')
 
 
@@ -126,7 +125,6 @@ def add_pipeline_menu():
         bpy.types.TOPBAR_MT_Pipeline.remove(import_menu)
         bpy.types.TOPBAR_MT_Pipeline.remove(export_menu)
         bpy.types.TOPBAR_MT_Pipeline.remove(utilities_menu)
-
 
     finally:
         bpy.types.TOPBAR_MT_Pipeline.append(import_menu)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
         'CONTAINER_REPO_FOLDER': CONTAINER_REPO_FOLDER,
         'HOST_TEST_FOLDER': HOST_TEST_FOLDER,
         'CONTAINER_TEST_FOLDER': CONTAINER_TEST_FOLDER,
-        'RPC_TIME_OUT': '20'
+        'RPC_TIME_OUT': '60'
     }
     # add the test environment variable if specified
     if TEST_ENVIRONMENT:
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     host_temp_folder = os.path.join(HOST_TEST_FOLDER, 'data')
     volumes = [
         f'{HOST_REPO_FOLDER}:{CONTAINER_REPO_FOLDER}',
-        f'{host_temp_folder}:/tmp/blender/send2ue'
+        f'{host_temp_folder}:/tmp/blender/send2ue/data'
     ]
 
     logging.debug(f'Launching ContainerTestManager...')
@@ -94,7 +94,7 @@ if __name__ == '__main__':
                 'rpc_port': UNREAL_PORT,
                 'environment': environment,
                 'volumes': volumes,
-                'tag': 'unreal-engine:dev-slim-5.0.0',
+                'tag': 'unreal-engine:dev-slim-5.0.1',
                 'repository': 'ghcr.io/epicgames',
                 'user': 'ue4',
                 'command': [
@@ -126,5 +126,5 @@ if __name__ == '__main__':
 
     container_test_manager.run_test_cases()
 
-    if TEST_ENVIRONMENT and os.environ.get('REMOVE_CONTAINERS', True):
+    if TEST_ENVIRONMENT and os.environ.get('REMOVE_CONTAINERS', '').lower() != 'false':
         container_test_manager.stop()

--- a/tests/test_files/send2ue_extensions/example_extension.py
+++ b/tests/test_files/send2ue_extensions/example_extension.py
@@ -17,80 +17,93 @@ class ExampleExtension(ExtensionBase):
     name = 'example'
 
     hello_property: bpy.props.StringProperty(default='Hello world')
+    use_example_extension: bpy.props.BoolProperty(default=False)
 
-    def draw_validations(self, dialog, layout):
+    def draw_validations(self, dialog, layout, properties):
         """
         Can be overridden to draw an interface for the extension under the validations tab.
 
-        :param Send2UeSceneProperties self: The scene property group that contains all the addon properties.
         :param Send2UnrealDialog dialog: The dialog class.
         :param bpy.types.UILayout layout: The extension layout area.
+        :param Send2UeSceneProperties properties: The scene property group that contains all the addon properties.
         """
         row = layout.row()
-        row.prop(self.extensions.example, 'hello_property')
+        row.prop(self, 'use_example_extension')
+        row.prop(self, 'hello_property')
 
-    def pre_operation(self):
+    def pre_operation(self, properties):
         """
-        Defines the pre operation logic that will be run before the operation.
+        Defines the pre operation task logic that will be run before the operation.
 
-        :param Send2UeSceneProperties self: The scene property group that contains all the addon properties.
+        :param Send2UeSceneProperties properties: The scene property group that contains all the addon properties.
         """
-        print('Before the Send to Unreal operation')
-        self.unreal_mesh_folder_path = '/Game/example_extension/test/'
-        self.unreal_animation_folder_path = '/Game/example_extension/test/animations'
+        if self.use_example_extension:
+            print('Before the Send to Unreal task')
+            properties.unreal_mesh_folder_path = '/Game/example_extension/test/'
+            properties.unreal_animation_folder_path = '/Game/example_extension/test/animations'
 
-    def pre_validations(self):
+    def pre_validations(self, properties):
         """
-        Defines the pre validation logic that will be an injected operation.
+        Defines the pre validation logic that will be an injected task.
 
-        :param Send2UeSceneProperties self: The scene property group that contains all the addon properties.
+        :param Send2UeSceneProperties properties: The scene property group that contains all the addon properties.
         """
-        print('Before Validations')
-        # Setting this to False will terminate execution in the validation phase
-        if self.extensions.example.hello_property != 'Hello world':
-            self.validations_passed = False
+        if self.use_example_extension:
+            print('Before Validations')
+            # Setting this to False will terminate execution in the validation phase
+            if self.hello_property != 'Hello world':
+                return False
+        return True
 
-    def pre_mesh_export(self):
+    def pre_mesh_export(self, asset_data, properties):
         """
-        Defines the pre mesh export logic that will be an injected operation.
+        Defines the pre mesh export logic that will be an injected task.
 
-        :param PropertyGroup self: The scene property group that contains all the addon properties.
+        :param dict asset_data: A mutable dictionary of asset data for the current asset being processed.
+        :param Send2UeSceneProperties properties: The scene property group that contains all the addon properties.
         """
-        # the asset data using the current asset id
-        path, ext = self.asset_data[self.asset_id]['file_path'].split('.')
-        asset_path = self.asset_data[self.asset_id]['asset_path']
+        if self.use_example_extension:
+            # the asset data using the current asset id
+            path, ext = asset_data['file_path'].split('.')
+            asset_path = asset_data['asset_path']
 
-        self.asset_data[self.asset_id]['file_path'] = f'{path}_added_this.{ext}'
-        self.asset_data[self.asset_id]['asset_path'] = f'{asset_path}_added_this'
+            asset_data['file_path'] = f'{path}_added_this.{ext}'
+            asset_data['asset_path'] = f'{asset_path}_added_this'
+            pprint(asset_data)
+            self.update_asset_data(asset_data)
 
-        pprint(self.asset_data[self.asset_id])
-
-    def pre_animation_export(self):
+    def pre_animation_export(self, asset_data, properties):
         """
-        Defines the pre animation export logic that will be an injected operation.
+        Defines the pre animation export logic that will be an injected task.
 
-        :param PropertyGroup self: The scene property group that contains all the addon properties.
+        :param dict asset_data: A mutable dictionary of asset data for the current asset being processed.
+        :param Send2UeSceneProperties properties: The scene property group that contains all the addon properties.
         """
-        print('Before Animation Export')
-        asset_data = self.asset_data[self.asset_id]
-        skeleton_asset_path = asset_data.get('skeleton_asset_path').replace('_Skeleton', '')
+        if self.use_example_extension:
+            print('Before Animation Export')
+            skeleton_asset_path = asset_data.get('skeleton_asset_path').replace('_Skeleton', '')
 
-        self.asset_data[self.asset_id]['skeleton_asset_path'] = f'{skeleton_asset_path}_added_this_Skeleton'
+            asset_data['skeleton_asset_path'] = f'{skeleton_asset_path}_added_this_Skeleton'
+            pprint(asset_data)
+            self.update_asset_data(asset_data)
 
-        pprint(self.asset_data[self.asset_id])
-
-    def post_import(self):
+    def post_import(self, asset_data, properties):
         """
-        Defines the post import logic that will be an injected operation.
+        Defines the post import logic that will be an injected task.
 
-        :param Send2UeSceneProperties self: The scene property group that contains all the addon properties.
+        :param dict asset_data: A mutable dictionary of asset data for the current asset being processed.
+        :param Send2UeSceneProperties properties: The scene property group that contains all the addon properties.
         """
-        print('After the import operation')
-        asset_path = self.asset_data[self.asset_id]['asset_path']
-        rename_unreal_asset(asset_path, f'{asset_path}_renamed_again')
+        if self.use_example_extension:
+            print('After the import task')
+            asset_path = asset_data['asset_path']
+            rename_unreal_asset(asset_path, f'{asset_path}_renamed_again')
 
-    def post_operation(self):
+    def post_operation(self, properties):
         """
-        Defines the post operation logic that will be run after the operation.
+        Defines the post operation task that will be run after the operation.
+
+        :param Send2UeSceneProperties properties: The scene property group that contains all the addon properties.
         """
-        print('After the Send to Unreal operation')
+        if self.use_example_extension:
+            print('After the Send to Unreal operation')

--- a/tests/test_send2ue_core.py
+++ b/tests/test_send2ue_core.py
@@ -22,35 +22,14 @@ class TestSend2UeCore(BaseSend2ueTestCaseCore):
         Checks that extensions load and function properly.
         """
         self.run_extension_tests({
-            'external': {
-                'example': {
-                    'properties': {'hello_property': 'Hello world'},
-                    'operators': [
-                        'extensions_example_post_operation',
-                        'extensions_example_pre_operation',
-                        'extensions_example_pre_validations'
-                    ],
-                    'draws': [
-                        'send2ue_extensions_example_draw_validations'
-                    ]
-                },
-            },
             'default': {
                 'ue2rigify': {
-                    'operators': [
-                        'extensions_ue2rigify_pre_validations'
+                    'tasks': [
+                        'extensions.ue2rigify.pre_validations'
                     ]
                 }
             }
         })
-
-        # A one off test against the ./test_files/send2ue_extensions/example.py extension
-        value = self.blender.get_addon_property('scene', self.addon_name, 'unreal_mesh_folder_path')
-        self.assertEqual(
-            value,
-            '/Game/example_extension/test/',
-            f'The unreal mesh folder "{value}" does not match the value it is set to in the example extension file'
-        )
 
     def test_templates(self):
         """

--- a/tests/test_send2ue_extension_affixes.py
+++ b/tests/test_send2ue_extension_affixes.py
@@ -57,28 +57,30 @@ class TestSend2UeExtensionAffixesCubes(TestSend2UeCubes, BaseSend2ueTestCaseCore
         Checks that the affix extension loaded properly.
         """
         self.run_extension_tests({
-            'affixes': {
-                'properties': {
-                    'auto_add_asset_name_affixes': True,
-                    'auto_remove_asset_name_affixes': True,
-                    'static_mesh_name_affix': 'SM_',
-                    'material_name_affix': 'M_',
-                    'texture_name_affix': 'T_',
-                    'skeletal_mesh_name_affix': 'SK_',
-                    'animation_sequence_name_affix': 'Anim_',
-                },
-                'operators': [
-                    'extensions_affixes_post_operation',
-                    'extensions_affixes_pre_operation',
-                    'extensions_affixes_pre_validations'
-                ],
-                'utility_operators': [
-                    'extensions_affixes_util_op_addassetaffixes',
-                    'extensions_affixes_util_op_removeassetaffixes'
-                ],
-                'draws': [
-                    'send2ue_extensions_affixes_draw_export'
-                ]
+            'default': {
+                'affixes': {
+                    'properties': {
+                        'auto_add_asset_name_affixes': True,
+                        'auto_remove_asset_name_affixes': False,
+                        'static_mesh_name_affix': 'SM_',
+                        'material_name_affix': 'M_',
+                        'texture_name_affix': 'T_',
+                        'skeletal_mesh_name_affix': 'SK_',
+                        'animation_sequence_name_affix': 'Anim_',
+                    },
+                    'tasks': [
+                        'extensions.affixes.post_operation',
+                        'extensions.affixes.pre_operation',
+                        'extensions.affixes.pre_validations'
+                    ],
+                    'utility_operators': [
+                        'extensions_affixes_addassetaffixes',
+                        'extensions_affixes_removeassetaffixes'
+                    ],
+                    'draws': [
+                        'extensions.affixes.draw_export'
+                    ]
+                }
             }
         })
 

--- a/tests/test_send2ue_extension_example.py
+++ b/tests/test_send2ue_extension_example.py
@@ -1,0 +1,94 @@
+import unittest
+import os
+from utils.base_test_case import BaseSend2ueTestCaseCore
+from test_send2ue_cubes import TestSend2UeCubes
+
+
+class TestSend2UeExtensionExampleCubes(TestSend2UeCubes, BaseSend2ueTestCaseCore):
+    """
+    Runs several test cases with the affix extension on the cube meshes.
+    """
+    def setUp(self):
+        super().setUp()
+        self.set_extension_repo(os.path.join(self.test_folder, 'test_files', 'send2ue_extensions'))
+        self.blender.set_addon_property('scene', 'send2ue', 'extensions.example.use_example_extension', True)
+
+    @unittest.skip
+    def test_bulk_send_to_unreal(self):
+        pass
+
+    @unittest.skip
+    def test_lods(self):
+        pass
+
+    @unittest.skip
+    def test_sockets(self):
+        pass
+
+    @unittest.skip
+    def test_collisions(self):
+        pass
+
+    @unittest.skip
+    def test_use_object_origin_option(self):
+        pass
+
+    @unittest.skip
+    def test_combine_child_meshes_option(self):
+        pass
+
+    @unittest.skip
+    def test_use_immediate_parent_collection_name_option(self):
+        pass
+
+    @unittest.skip
+    def test_use_collections_as_folders_option(self):
+        pass
+
+    @unittest.skip
+    def test_materials(self):
+        pass
+
+    @unittest.skip
+    def test_textures(self):
+        pass
+
+    def test_extension(self):
+        """
+        Checks that extensions load and function properly.
+        """
+        self.run_extension_tests({
+            'external': {
+                'example': {
+                    'properties': {'hello_property': 'Hello world'},
+                    'tasks': [
+                        'extensions.example.post_operation',
+                        'extensions.example.pre_operation',
+                        'extensions.example.pre_validations'
+                    ],
+                    'draws': [
+                        'extensions.example.draw_validations'
+                    ]
+                },
+            }
+        })
+
+    @unittest.skip
+    def test_import_asset_operator(self):
+        pass
+
+    def test_default_send_to_unreal(self):
+        """
+        Sends a cube mesh with default settings.
+        """
+        self.move_to_collection(['Cube1_LOD0'], 'Export')
+        self.send2ue_operation()
+        self.assert_mesh_import('Cube1_LOD0_added_this_renamed_again')
+
+        # A one off test against the ./test_files/send2ue_extensions/example.py extension
+        value = self.blender.get_addon_property('scene', self.addon_name, 'unreal_mesh_folder_path')
+        self.assertEqual(
+            value,
+            '/Game/example_extension/test/',
+            f'The unreal mesh folder "{value}" does not match the value it is set to in the example extension file'
+        )

--- a/ue2rigify/core/scene.py
+++ b/ue2rigify/core/scene.py
@@ -1108,7 +1108,7 @@ def sync_nla_track_data(control_rig_object, source_rig_object):
                     # create a new nla strip on the source rig
                     source_strip = source_nla_track.strips.new(
                         name=control_strip.name,
-                        start=control_strip.frame_start,
+                        start=int(control_strip.frame_start),
                         action=source_action
                     )
 


### PR DESCRIPTION
# Send to Unreal 2.1.0

## Major Changes
* Factored Extension factory and class (Breaking changes. Old Extension classes need to be updated to be compatible with 2.1.0)
  * https://github.com/EpicGames/BlenderTools/issues/453
* Added build nanite option in [Static Mesh Import Data](https://docs.unrealengine.com/5.0/en-US/PythonAPI/class/FbxStaticMeshImportData.html?highlight=fbxstaticmeshimportdata#unreal.FbxStaticMeshImportData) for unreal 5
  * https://github.com/EpicGames/BlenderTools/issues/421
* Replaced EditorStaticMeshLibrary calls with StaticMeshEditorSubsystem (breaks UE4 support, but this library will be deprecated in UE5)
* Replaced EditorSkeletalMeshLibrary calls with SkeletalMeshEditorSubsystem (breaks UE4 support, but this library will be deprecated in UE5)

## Minor Changes
* Default blender FBX export Geometry smoothing changed from `Normals Only`, to `Face`
* Fixed multiple progress bar bug when exception triggered
* Fixed Export to Disk path validation bug
  * https://github.com/EpicGames/BlenderTools/issues/420
  * https://github.com/EpicGames/BlenderTools/issues/419

## Documentation Changes
* Updated [Extension docs](https://epicgames.github.io/BlenderTools/send2ue/customize/extensions.html)

## Deprecated
* Blender `2.93`,`3.0` support (No longer testing. Your mileage may vary)
* Unreal `4.27` support (Breaking unreal api changes. Use send2ue 2.0.2 or older)

## Tests Passing On
* Blender `3.1`, `3.2`
* Unreal `5.0.1`
