### PR TITLE
Added community templates page to UE to Rigify docs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/community_extension.md
+++ b/.github/ISSUE_TEMPLATE/community_extension.md
@@ -1,8 +1,8 @@
 ---
-name: Community Extension
-about: Create a request to have your extension listed on the docs as a community extension.
+name: Send to Unreal Community Extension
+about: Create a request to have your extension listed on the Send to Unreal docs as a community extension.
 title: ''
-labels: community-extension
+labels: send2ue-community-extension
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/community_template.md
+++ b/.github/ISSUE_TEMPLATE/community_template.md
@@ -1,0 +1,19 @@
+---
+name: UE to Rigify Community Template
+about: Create a request to have your template listed on the UE to Rigify docs as a community template.
+title: ''
+labels: ue2rigify-community-template
+assignees: ''
+
+---
+
+### Checklist:
+  1. Is the template in a public GitHub repo?
+  1. Does the template have a link to publicly README describing the template and what rig it is designed for?
+
+Give a brief description of your template and why you think it would be valuable for others.
+
+### Notice:
+We reserve the right to remove your template from the community page for these or any other reasons:
+* Out of date template that is no longer compatible with the latest supported version of UE to Rigify.
+* Malicious or suspicious activity

--- a/docs/ue2rigify/.vuepress/config.js
+++ b/docs/ue2rigify/.vuepress/config.js
@@ -76,6 +76,13 @@ module.exports = {
                     ]
                 },
                 {
+                    title: 'Extras',
+                    collapsable: false,
+                    children: [
+                        'extras/community-templates'
+                    ]
+                },
+                {
                     title: 'Trouble Shooting',
                     collapsable: false,
                     children: [

--- a/docs/ue2rigify/extras/community-templates.md
+++ b/docs/ue2rigify/extras/community-templates.md
@@ -1,0 +1,27 @@
+# Community Templates
+
+UE to Rigify templates are a powerful way to share rigs and retarget animation regardless of
+what app the skeleton and skin weights were originally created with. As the number of templates created grows,
+we want this page to be filled with links to templates that the community has authored, and can hopefully help others
+with their blender and unreal pipelines.
+
+### Guidelines
+
+In order to have your template linked to this page, several requirements must be met.
+
+### Requirements
+  * Code must be in a public GitHub repo
+  * Must have a link to a publicly available README with a brief description of the template and what rig it is designed for.
+
+### Notice
+We reserve the right to remove your template link from this page for these or any other reasons:
+* Out of date template that is no longer compatible with the latest supported version of UE to Rigify.
+* Malicious or suspicious activity
+
+### Liability
+This page is a list of community templates that you are free to explore, but we do not support them in any way.  We are in no way responsible for
+the templates you decide to download. When you decide to download any of these templates you accept that
+you are exposing yourself to security vulnerabilities and potential system failure. Always use caution. Read through
+the code or consult a security professional before proceeding to download code from the internet. Any issues that you have with the template
+must be reported to the template author not to us.
+


### PR DESCRIPTION
-  community templates page to UE to Rigify docs so that other users of the tools can link their templates to the docs.
- added a issue template that users can open in order to get templates added to the UE to Rigify docs