### PR TITLE
Fixed an issue where exported sockets on static meshes would be lost …

### DIFF
--- a/send2ue/dependencies/unreal.py
+++ b/send2ue/dependencies/unreal.py
@@ -636,6 +636,22 @@ class UnrealRemoteCalls:
         return bool(mesh.find_socket(socket_name))
 
     @staticmethod
+    def has_socket_outer(asset_path, socket_name):
+        """
+        Checks to see if an asset has a socket and the owner (outer) is assigned to the mesh.
+
+        :param str asset_path: The path to the unreal asset.
+        :param str socket_name: The name of the socket to look for.
+        :return bool: Whether or not the asset has the given socket and the owner (outer) is properly assigned or not.
+        """
+        mesh = Unreal.get_asset(asset_path)
+        socket = mesh.find_socket(socket_name)
+        if socket:
+            return socket.get_outer() == mesh
+        else:
+            return False
+
+    @staticmethod
     def delete_asset(asset_path):
         """
         Deletes an asset in unreal.
@@ -809,7 +825,7 @@ class UnrealRemoteCalls:
         """
         static_mesh = Unreal.get_asset(asset_path)
         for socket_name, socket_data in asset_data.get('sockets').items():
-            socket = unreal.StaticMeshSocket()
+            socket = unreal.StaticMeshSocket(static_mesh)
 
             # apply the socket settings
             socket.set_editor_property('relative_location', socket_data.get('relative_location'))

--- a/tests/utils/base_test_case.py
+++ b/tests/utils/base_test_case.py
@@ -392,6 +392,10 @@ class BaseSend2ueTestCase(BaseTestCase):
             self.unreal.has_socket(asset_path, socket_name),
             f'The socket "{socket_name}" could not be found on "{asset_name}" in unreal.'
         )
+        self.assertTrue(
+            self.unreal.has_socket_outer(asset_path, socket_name),
+            f'The socket "{socket_name}" is not owned by "{asset_name}" in unreal.'
+        )
 
     def assert_collision(self, asset_name, simple_count=0, convex_count=0):
         self.log(f'Checking "{asset_name}" for collision...')


### PR DESCRIPTION
…after re-opening a project (missing reference causing crashes).

Mentioned in issues #492 and #443

3 unit tests failed for me. They don't seem related to anything I changed, so maybe tests that are currently failing, or I have an issue in my setup.

======================================================================
FAIL [17.620s]: test_materials (test_send2ue_extension_affixes.TestSend2UeExtensionAffixesMannequins)
Sends a mannequin with materials to unreal.
----------------------------------------------------------------------
AssertionError: False is not true : The material "M_MI_Female_Body" does not exist in unreal.

======================================================================
FAIL [17.249s]: test_textures (test_send2ue_extension_affixes.TestSend2UeExtensionAffixesMannequins)
Sends a mannequin with a textured material to unreal.
----------------------------------------------------------------------
AssertionError: False is not true : The texture "T_unreal-engine-logo" does not exist in unreal.

======================================================================
FAIL [22.269s]: test_textures (test_send2ue_mannequins.TestSend2UeMannequins)
Sends a mannequin with a textured material to unreal.
----------------------------------------------------------------------
AssertionError: False is not true : The texture "unreal-engine-logo" does not exist in unreal.