### PR TITLE
Docs change for send2ue under Morph Target section

### DIFF
--- a/docs/send2ue/asset-types/animation.md
+++ b/docs/send2ue/asset-types/animation.md
@@ -70,6 +70,10 @@ In this example a driver is created so that a custom float property `head_swell`
 value. Furthermore, that custom property value is keyed in the `third_person_walk01` action.
 
 ::: tip Note
+   Both the custom property and the driven shape key must have the same exact name in order for unreal to recognize it!
+:::
+
+::: tip Note
    This is what the driver settings look like:
 ![7](./images/animation/7.png)
 :::


### PR DESCRIPTION
Shape-key animations are not sent to UE if the custom property and the driven shape keys have different names. I propose you mention that you need to have both the custom property and the shape key to have the same exact name so that it works. Check line 72-73-74 that I proposed.