### PR TITLE
Fix socket exception

### DIFF
--- a/send2ue/core/ingest.py
+++ b/send2ue/core/ingest.py
@@ -22,7 +22,7 @@ def import_asset(asset_id, property_data):
     asset_data = bpy.context.window_manager.send2ue.asset_data[asset_id]
 
     # import the asset
-    UnrealRemoteCalls.import_asset(asset_data.get('file_path'), asset_data, property_data)
+    asset_data['asset_path'] = UnrealRemoteCalls.import_asset(asset_data.get('file_path'), asset_data, property_data)[0]
 
     # import fcurves
     if asset_data.get('fcurve_file_path'):


### PR DESCRIPTION
updated unreal.py so the set_static_mesh_sockets function get the asset with it's reference path, not the filepath

Issue : https://github.com/EpicGames/BlenderTools/issues/523