### PR TITLE
Validation fix: detect invalid material assigned to polygon.

### DIFF
--- a/send2ue/core/validations.py
+++ b/send2ue/core/validations.py
@@ -209,7 +209,7 @@ class ValidationManager:
                     for polygon in mesh_object.data.polygons:
                         if polygon.material_index >= len(mesh_object.material_slots):
                             utilities.report_error('Material index out of bounds!', f'Object "{mesh_object.name}" at polygon #{polygon.index} references invalid material index #{polygon.material_index}.')
-                            continue
+                            return False
 
                         material = mesh_object.material_slots[polygon.material_index].name
                         # remove used material names from the list of unused material names


### PR DESCRIPTION
Encountered this while swapping some materials in my scene to use a shared file, which caused some polys on preexisting meshes to point to invalid materials. On validation, `mesh_object.material_slots[polygon.material_index]` threw a very vague exception that took me a few hours to track down. Now instead, it will raise an error point to the exact mesh + polygon that is invalid.