### PR TITLE
Add collections as folder support for 'send to disk'

### DIFF
--- a/send2ue/resources/extensions/use_collections_as_folders.py
+++ b/send2ue/resources/extensions/use_collections_as_folders.py
@@ -56,7 +56,6 @@ class UseCollectionsAsFoldersExtension(ExtensionBase):
         sub_path = self.get_collections_as_path(scene_object, properties)
         export_path = os.path.join(game_path, sub_path)
         return export_path
-    
 
     def pre_import(self, asset_data, properties):
         """


### PR DESCRIPTION
Adding collections as folder support for 'send to disk'.

Tested in all 3 modes. [Send to disk, send to disk then project, send to project]
Appears to work as intended in my test. See screenshot for my example case.

I don't have animations or grooms to test those though.

![epPzyZBrlw](https://github.com/EpicGames/BlenderTools/assets/1614040/9996cb2a-d276-4623-bec8-49a0def9a598)

Also see Issue #608
